### PR TITLE
restart with interval of 1s and max delay of 5m

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+jenkins-agent (1.0.6) jammy; urgency=medium
+
+  * Add auto restart for systemd service
+
+ -- tphan025 <trung.thanh.phan@canonical.com>  Thu, 07 Mar 2024 12:59:04 +0100
+
 jenkins-agent (1.0.5) jammy; urgency=medium
 
   * Add ExecStopPost to .service to cleanup after stopping

--- a/debian/jenkins-agent.service
+++ b/debian/jenkins-agent.service
@@ -1,8 +1,11 @@
 [Unit]
 Description=Jenkins inbound agent
+StartLimitIntervalSec=5m
 
 [Service]
 Type=simple
+Restart=on-failure
+RestartSec=1s
 ExecStart=/usr/bin/jenkins-agent
 ExecStopPost=rm -rf /var/lib/jenkins/.ready
 


### PR DESCRIPTION
Pebble (used in jenkins-agent-k8s-operator) automatically restarts service on-failure. So we need to also automatically restart the agent service to make the machine agent's behavior similar to that of the k8s agent. 